### PR TITLE
Remove date from docker image tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
   apt-get update &&\ 
   apt-get install -y \
     apt-utils \
-    python-pip \
+    python3-pip \
     createrepo \
     debhelper \
     devscripts \
@@ -25,5 +25,5 @@ RUN \
     tzdata \
     unzip &&\
   apt-get clean &&\ 
-  pip install jinja2  && \
+  pip3 install jinja2  && \
   rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: .build
 
 IMAGE = 'jenkinsciinfra/packaging'
-TAG = $(shell git rev-parse HEAD | cut -c1-6)-$(shell date +%Y%m%d)
+TAG = $(shell git rev-parse HEAD | cut -c1-6)
 
 build:
 	docker build --no-cache -t $(IMAGE):$(TAG) -t $(IMAGE):latest -f Dockerfile .


### PR DESCRIPTION
Using the date in the tag wasn't a good idea and it only leads to a lot of different tag referencing the same docker image