### PR TITLE
fix: add gpg dependency in the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     debhelper \
     devscripts \
     expect \
+    gpg \
     make \
     maven \
     openssh-server \


### PR DESCRIPTION
Without it, weekly build 2.322 failed during packaging because the gpg command was not available on the agent.