### PR TITLE
fix: add missing git dependency to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN \
     debhelper \
     devscripts \
     expect \
+    git \
     gpg \
     make \
     maven \


### PR DESCRIPTION
Removed since `--no-install-recommends` has been added.