### PR TITLE
fix: add missing openssl dependency to the Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN \
     make \
     maven \
     openssh-server \
+    openssl \
     python3-pip \
     rpm \
     rsync \


### PR DESCRIPTION
Removed since `--no-install-recommends` has been added.