### PR TITLE
fix: switch linux packaging to single-container JNLP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,15 @@ RUN apt-get update \
   && echo "JAVA_HOME=${JAVA_HOME}" >> /etc/environment \
   && java -version
 
+## Maven is required for Debian packaging step (at least)
+ARG MAVEN_VERSION=3.8.4
+RUN curl --fail --silent --location --show-error --output "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  "https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  && tar zxf "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" -C /usr/share/ \
+  && ln -s "/usr/share/apache-maven-${MAVEN_VERSION}/bin/mvn" /usr/local/bin/mvn \
+  && rm -f "/tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" \
+  && mvn -version
+
 ## We need some files from the official jenkins-agent image
 COPY --from=jenkins-agent /usr/share/jenkins/agent.jar /usr/share/jenkins/agent.jar
 COPY --from=jenkins-agent /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-agent


### PR DESCRIPTION
WiP...

- Bump Maven to 3.8.4 (instead of ubuntu 18 default package)
- Bump JDK 8 to 11:
  - Adoptium (instead of OpenJDK's Ubuntu 18 default)
  - Pin version to 11.0.13+8
- Define the image as a Jenkins Inbound Agent capable image, to unlock the ability for single-container pod
  - Retrieve the agent.jar and entrypoint shell script from the official jenkinsci/docker-inbound-agent repository
- Add dependencies required by other "side container" on jenkins-infra/release project:
  - `az` CLI
  - `jx-release-version` CLI
  - `gh` CLI
- Chore: start adding labels with the installed tools and versions