### PR TITLE
Install additional packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update \
     openssh-server \
     openssl \
     python3-pip \
+    python3-pytest \
+    python3-venv \
     rpm \
     rsync \
     tzdata \


### PR DESCRIPTION
I'd like to be able to run the unit tests for `jenkinsci/packaging` in `pytest` rather than `unittest`. The `pytest` test runner provides support for generating JUnit XML files, which can be used with the Jenkins JUnit plugin to provide a visual test result report in the Jenkins UI.

This PR adds the `python3-pytest` package, which I've tested in a local build and confirmed to be able to generate JUnit XML results in `jenkinsci/packaging`.

As a bonus, I'm also adding `python3-venv`. This isn't needed for what I'm doing, but it's a prerequisite for doing just about anything interesting with Python, so we might as well include it.