### PR TITLE
fix: add (default)jdk bin to the path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,10 +119,12 @@ RUN apt-get update \
 
 ## Define the default java to be used
 ENV JAVA_HOME="${JDK8_HOME}"
+ENV PATH "${JAVA_HOME}/bin:$PATH"
 ## Use 1000 to be sure weight is always the bigger
 RUN update-alternatives --install /usr/bin/java java "${JAVA_HOME}"/bin/java 1000 \
 # Ensure JAVA_HOME variable is availabel to all shells
   && echo "JAVA_HOME=${JAVA_HOME}" >> /etc/environment \
+  && echo "PATH=${JAVA_HOME}/bin:$PATH" >> /etc/environment \
   && java -version
 
 ## Maven is required for Debian packaging step (at least)


### PR DESCRIPTION
The 2.331 release failed with the following error:

```
+ jarsigner -verbose -verify -certs -strict /home/jenkins/agent/workspace/core_release_master/release/war/target/jenkins.war
utils/release.bash: line 476: jarsigner: command not found
```

We are missing https://github.com/docker-library/openjdk/blob/3ce4449d7f01afa6001a711e17cdd379b76848f8/8/jdk/bullseye/Dockerfile#L28 in this image.

This PR aims at fixing it by adding the whole default (JDK8) bin to the PATH.

Result is:

```shell
docker run --rm -ti --entrypoint bash <new image in this PR>
jenkins@6b9761c20cbb:/$ java -version
openjdk version "1.8.0_312"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_312-b07)
OpenJDK 64-Bit Server VM (Temurin)(build 25.312-b07, mixed mode)
jenkins@6b9761c20cbb:/$ 
jenkins@6b9761c20cbb:/$ which jarsigner
/opt/jdk-8/bin/jarsigner
```