### PR TITLE
Bump Ubuntu from 18.04 to 22.04 and Azure CLI from 2.0.59 to 2.32.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ ENV TZ=UTC
 ENV LANG C.UTF-8
 
 ## Always install the latest package and pip versions
+## TODO: Remove the "ln -s /usr/bin/createrepo_c /usr/bin/createrepo" call
+## below once all consumers have been migrated from "createrepo" to
+## "createrepo_c".
 # hadolint ignore=DL3008,DL3013
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends \
@@ -37,6 +40,7 @@ RUN apt-get update \
     rsync \
     tzdata \
     unzip \
+  && ln -s /usr/bin/createrepo_c /usr/bin/createrepo \
   && apt-get clean \
   && pip3 install --no-cache-dir jinja2 \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
There is no specific driver for this PR, but I generally prefer having the latest toolchain when working. In my experience this typically makes development significantly easier compared to working on outdated toolchains. While Ubuntu 22.04 has not officially been released yet, we're close enough to April 2022 and far enough away from April 2018 that I think this is OK.

Upgrading the Ubuntu distribution also required updating the Azure CLI to the latest version. Since I couldn't find any Microosft repositories for `jammy` or `impish`, I did the next-best thing and picked the repository for `hirsute`. Once Microsoft provides a repository for `jammy`, we can switch to that in the future.

To test this change, I successfully built the `.deb`, `.rpm`, and SUSE packages. I also ran the Molecule tests against the resulting packages on Ubuntu 22.04, Fedora 35, and openSUSE Leap 15. All testing was successful.

CC @dduportal