### PR TITLE
Add systemd RPM macros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,7 @@ COPY --from=jenkins-agent /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-ag
 ## Copy packaging-specific RPM macros
 COPY ./conf.d/rpm_macros /etc/rpm/macros
 COPY ./conf.d/devscripts.conf /etc/devscripts.conf
+COPY ./macros.d/macros.systemd /usr/lib/rpm/macros.d/macros.systemd
 
 # Create default user (must be the same as the official jenkins-agent image)
 ARG JENKINS_USERNAME=jenkins

--- a/macros.d/macros.systemd
+++ b/macros.d/macros.systemd
@@ -1,0 +1,176 @@
+#  -*- Mode: rpm-spec; indent-tabs-mode: nil -*- */
+#  SPDX-License-Identifier: LGPL-2.1-or-later
+#
+#  This file is part of systemd.
+#  Copied from https://github.com/systemd/systemd/blob/main/src/rpm/macros.systemd.in
+
+# RPM macros for packages installing systemd unit files
+
+%_systemd_util_dir /usr/lib/systemd
+%_unitdir /usr/lib/systemd/system
+%_userunitdir /usr/lib/systemd/user
+%_presetdir /usr/lib/systemd/system-preset
+%_userpresetdir /usr/lib/systemd/user-preset
+%_udevhwdbdir /usr/lib/udev/hwdb.d
+%_udevrulesdir /usr/lib/udev/rules.d
+%_journalcatalogdir /usr/lib/systemd/catalog
+%_binfmtdir /usr/lib/binfmt.d
+%_sysctldir /usr/lib/sysctl.d
+%_sysusersdir /usr/lib/sysusers.d
+%_tmpfilesdir /usr/lib/tmpfiles.d
+%_environmentdir /usr/lib/environment.d
+%_modulesloaddir /usr/lib/modules-load.d
+%_modprobedir /usr/lib/modprobe.d
+%_systemdgeneratordir /usr/lib/systemd/system-generators
+%_systemdusergeneratordir /usr/lib/systemd/user-generators
+%_systemd_system_env_generator_dir /usr/lib/systemd/system-environment-generators
+%_systemd_user_env_generator_dir /usr/lib/systemd/user-environment-generators
+
+# Because we had one release with a typo...
+# This is temporary (Remove after systemd 240 is released)
+%_environmnentdir %{warn:Use %%_environmentdir instead}%_environmentdir
+
+%systemd_requires \
+Requires(post): systemd \
+Requires(preun): systemd \
+Requires(postun): systemd \
+%{nil}
+
+%systemd_ordering \
+OrderWithRequires(post): systemd \
+OrderWithRequires(preun): systemd \
+OrderWithRequires(postun): systemd \
+%{nil}
+
+%__systemd_someargs_0(:) %{error:The %%%1 macro requires some arguments}
+%__systemd_twoargs_2() %{nil}
+
+%systemd_post() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_post}} \
+if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Initial installation \
+    /usr/lib/systemd/systemd-update-helper install-system-units %{?*} || : \
+fi \
+%{nil}
+
+%systemd_user_post() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_post}} \
+if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Initial installation \
+    /usr/lib/systemd/systemd-update-helper install-user-units %{?*} || : \
+fi \
+%{nil}
+
+%systemd_preun() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_preun}} \
+if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Package removal, not upgrade \
+    /usr/lib/systemd/systemd-update-helper remove-system-units %{?*} || : \
+fi \
+%{nil}
+
+%systemd_user_preun() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_preun}} \
+if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Package removal, not upgrade \
+    /usr/lib/systemd/systemd-update-helper remove-user-units %{?*} || : \
+fi \
+%{nil}
+
+%systemd_postun() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_postun}} \
+%{nil}
+
+%systemd_user_postun() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_postun}} \
+%{nil}
+
+%systemd_postun_with_restart() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_postun_with_restart}} \
+if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Package upgrade, not uninstall \
+    /usr/lib/systemd/systemd-update-helper mark-restart-system-units %{?*} || : \
+fi \
+%{nil}
+
+%systemd_user_postun_with_restart() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_postun_with_restart}} \
+if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
+    # Package upgrade, not uninstall \
+    /usr/lib/systemd/systemd-update-helper mark-restart-user-units %{?*} || : \
+fi \
+%{nil}
+
+%udev_hwdb_update() %{nil}
+
+%udev_rules_update() %{nil}
+
+%journal_catalog_update() %{nil}
+
+# Deprecated. Use %tmpfiles_create_package instead
+%tmpfiles_create() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# tmpfiles_create}} \
+command -v systemd-tmpfiles >/dev/null && systemd-tmpfiles --create %{?*} || : \
+%{nil}
+
+# Deprecated. Use %sysusers_create_package instead
+%sysusers_create() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysusers_create}} \
+command -v systemd-sysusers >/dev/null && systemd-sysusers %{?*} || : \
+%{nil}
+
+%sysusers_create_inline() \
+command -v systemd-sysusers >/dev/null && systemd-sysusers - <<SYSTEMD_INLINE_EOF || : \
+%{?*} \
+SYSTEMD_INLINE_EOF\
+%{nil}
+
+# This should be used by package installation scripts which require users or
+# groups to be present before the files installed by the package are present on
+# disk (for example because some files are owned by those users or groups).
+#
+# Example:
+#   Source1: %{name}-sysusers.conf
+#   ...
+#   %install
+#   install -D %SOURCE1 %{buildroot}%{_sysusersdir}/%{name}.conf
+#   %pre
+#   %sysusers_create_package %{name} %SOURCE1
+#   %files
+#   %{_sysusersdir}/%{name}.conf
+%sysusers_create_package() \
+%{expand:%%{?!__systemd_twoargs_%#:%%{error:The %%%%sysusers_create_package macro requires two arguments}}} \
+systemd-sysusers --replace=%_sysusersdir/%1.conf - <<SYSTEMD_INLINE_EOF || : \
+%(cat %2) \
+SYSTEMD_INLINE_EOF\
+%{nil}
+
+# This may be used by package installation scripts to create files according to
+# their tmpfiles configuration from a package installation script, even before
+# the files of that package are installed on disk.
+#
+# Example:
+#   Source1: %{name}-tmpfiles.conf
+#   ...
+#   %install
+#   install -D %SOURCE1 %{buildroot}%{_tmpfilesdir}/%{name}.conf
+#   %pre
+#   %tmpfiles_create_package %{name} %SOURCE1
+#   %files
+#   %{_tmpfilesdir}/%{name}.conf
+%tmpfiles_create_package() \
+%{expand:%%{?!__systemd_twoargs_%#:%%{error:The %%%%tmpfiles_create_package macro requires two arguments}}} \
+systemd-tmpfiles --replace=%_tmpfilesdir/%1.conf --create - <<SYSTEMD_INLINE_EOF || : \
+%(cat %2) \
+SYSTEMD_INLINE_EOF\
+%{nil}
+
+%sysctl_apply() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysctl_apply}} \
+[ -x /usr/lib/systemd/systemd-sysctl ] && /usr/lib/systemd/systemd-sysctl %{?*} || : \
+%{nil}
+
+%binfmt_apply() \
+%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# binfmt_apply}} \
+[ -x /usr/lib/systemd/systemd-binfmt ] && /usr/lib/systemd/systemd-binfmt %{?*} || : \
+%{nil}


### PR DESCRIPTION
Downstream of #28. Expanded from:

https://github.com/systemd/systemd/blob/main/src/rpm/macros.systemd.in

These macros are needed to build RPM packages that use `systemd`, but as far as I can tell they aren't packaged anywhere in Debian and Ubuntu. By including this in the base image, we can build RPMs that use `systemd` from Debian/Ubuntu.