### PR TITLE
Use older systemd RPM macros

### DIFF
--- a/macros.d/macros.systemd
+++ b/macros.d/macros.systemd
@@ -1,12 +1,13 @@
 #  -*- Mode: rpm-spec; indent-tabs-mode: nil -*- */
-#  SPDX-License-Identifier: LGPL-2.1-or-later
+#  SPDX-License-Identifier: LGPL-2.1+
 #
 #  This file is part of systemd.
-#  Copied from https://github.com/systemd/systemd/blob/main/src/rpm/macros.systemd.in
+#  Copied from https://github.com/systemd/systemd/blob/v239/src/core/macros.systemd.in
+#
+#  Copyright 2012 Lennart Poettering
 
 # RPM macros for packages installing systemd unit files
 
-%_systemd_util_dir /usr/lib/systemd
 %_unitdir /usr/lib/systemd/system
 %_userunitdir /usr/lib/systemd/user
 %_presetdir /usr/lib/systemd/system-preset
@@ -26,10 +27,6 @@
 %_systemd_system_env_generator_dir /usr/lib/systemd/system-environment-generators
 %_systemd_user_env_generator_dir /usr/lib/systemd/user-environment-generators
 
-# Because we had one release with a typo...
-# This is temporary (Remove after systemd 240 is released)
-%_environmnentdir %{warn:Use %%_environmentdir instead}%_environmentdir
-
 %systemd_requires \
 Requires(post): systemd \
 Requires(preun): systemd \
@@ -42,64 +39,41 @@ OrderWithRequires(preun): systemd \
 OrderWithRequires(postun): systemd \
 %{nil}
 
-%__systemd_someargs_0(:) %{error:The %%%1 macro requires some arguments}
-%__systemd_twoargs_2() %{nil}
-
 %systemd_post() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_post}} \
-if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Initial installation \
-    /usr/lib/systemd/systemd-update-helper install-system-units %{?*} || : \
+if [ $1 -eq 1 ] ; then \
+        # Initial installation \
+        systemctl --no-reload preset %{?*} &>/dev/null || : \
 fi \
 %{nil}
 
-%systemd_user_post() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_post}} \
-if [ $1 -eq 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Initial installation \
-    /usr/lib/systemd/systemd-update-helper install-user-units %{?*} || : \
-fi \
-%{nil}
+%systemd_user_post() %{expand:%systemd_post \\--global %%{?*}}
 
 %systemd_preun() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_preun}} \
-if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Package removal, not upgrade \
-    /usr/lib/systemd/systemd-update-helper remove-system-units %{?*} || : \
+if [ $1 -eq 0 ] ; then \
+        # Package removal, not upgrade \
+        systemctl --no-reload disable --now %{?*} &>/dev/null || : \
 fi \
 %{nil}
 
 %systemd_user_preun() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_preun}} \
-if [ $1 -eq 0 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Package removal, not upgrade \
-    /usr/lib/systemd/systemd-update-helper remove-user-units %{?*} || : \
+if [ $1 -eq 0 ] ; then \
+        # Package removal, not upgrade \
+        systemctl --global disable %{?*} &>/dev/null || : \
 fi \
 %{nil}
 
-%systemd_postun() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_postun}} \
-%{nil}
+%systemd_postun() %{nil}
 
-%systemd_user_postun() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_postun}} \
-%{nil}
+%systemd_user_postun() %{nil}
 
 %systemd_postun_with_restart() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_postun_with_restart}} \
-if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Package upgrade, not uninstall \
-    /usr/lib/systemd/systemd-update-helper mark-restart-system-units %{?*} || : \
+if [ $1 -ge 1 ] ; then \
+        # Package upgrade, not uninstall \
+        systemctl try-restart %{?*} &>/dev/null || : \
 fi \
 %{nil}
 
-%systemd_user_postun_with_restart() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# systemd_user_postun_with_restart}} \
-if [ $1 -ge 1 ] && [ -x "/usr/lib/systemd/systemd-update-helper" ]; then \
-    # Package upgrade, not uninstall \
-    /usr/lib/systemd/systemd-update-helper mark-restart-user-units %{?*} || : \
-fi \
-%{nil}
+%systemd_user_postun_with_restart() %{nil}
 
 %udev_hwdb_update() %{nil}
 
@@ -109,20 +83,18 @@ fi \
 
 # Deprecated. Use %tmpfiles_create_package instead
 %tmpfiles_create() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# tmpfiles_create}} \
-command -v systemd-tmpfiles >/dev/null && systemd-tmpfiles --create %{?*} || : \
+systemd-tmpfiles --create %{?*} &>/dev/null || : \
 %{nil}
 
 # Deprecated. Use %sysusers_create_package instead
 %sysusers_create() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysusers_create}} \
-command -v systemd-sysusers >/dev/null && systemd-sysusers %{?*} || : \
+systemd-sysusers %{?*} &>/dev/null || : \
 %{nil}
 
 %sysusers_create_inline() \
-command -v systemd-sysusers >/dev/null && systemd-sysusers - <<SYSTEMD_INLINE_EOF || : \
+systemd-sysusers - <<SYSTEMD_INLINE_EOF &>/dev/null || : \
 %{?*} \
-SYSTEMD_INLINE_EOF\
+SYSTEMD_INLINE_EOF \
 %{nil}
 
 # This should be used by package installation scripts which require users or
@@ -139,10 +111,9 @@ SYSTEMD_INLINE_EOF\
 #   %files
 #   %{_sysusersdir}/%{name}.conf
 %sysusers_create_package() \
-%{expand:%%{?!__systemd_twoargs_%#:%%{error:The %%%%sysusers_create_package macro requires two arguments}}} \
-systemd-sysusers --replace=%_sysusersdir/%1.conf - <<SYSTEMD_INLINE_EOF || : \
+systemd-sysusers --replace=%_sysusersdir/%1.conf - <<SYSTEMD_INLINE_EOF &>/dev/null || : \
 %(cat %2) \
-SYSTEMD_INLINE_EOF\
+SYSTEMD_INLINE_EOF \
 %{nil}
 
 # This may be used by package installation scripts to create files according to
@@ -159,18 +130,15 @@ SYSTEMD_INLINE_EOF\
 #   %files
 #   %{_tmpfilesdir}/%{name}.conf
 %tmpfiles_create_package() \
-%{expand:%%{?!__systemd_twoargs_%#:%%{error:The %%%%tmpfiles_create_package macro requires two arguments}}} \
-systemd-tmpfiles --replace=%_tmpfilesdir/%1.conf --create - <<SYSTEMD_INLINE_EOF || : \
+systemd-tmpfiles --replace=%_tmpfilesdir/%1.conf --create - <<SYSTEMD_INLINE_EOF &>/dev/null || : \
 %(cat %2) \
-SYSTEMD_INLINE_EOF\
+SYSTEMD_INLINE_EOF \
 %{nil}
 
 %sysctl_apply() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# sysctl_apply}} \
-[ -x /usr/lib/systemd/systemd-sysctl ] && /usr/lib/systemd/systemd-sysctl %{?*} || : \
+/usr/lib/systemd/systemd-sysctl %{?*} &>/dev/null || : \
 %{nil}
 
 %binfmt_apply() \
-%{expand:%%{?__systemd_someargs_%#:%%__systemd_someargs_%# binfmt_apply}} \
-[ -x /usr/lib/systemd/systemd-binfmt ] && /usr/lib/systemd/systemd-binfmt %{?*} || : \
+/usr/lib/systemd/systemd-binfmt %{?*} &>/dev/null || : \
 %{nil}


### PR DESCRIPTION
@ekohl points out in #29 and jenkinsci/packaging#266 that the macros added in #29 rely on systemd v250, which is quite new. This PR downgrades the macros to the ones from systemd v239, which should work on older Linux distribution versions.

I tested this by running the Molecule tests from jenkinsci/packaging#266 successfully.

CC @dduportal @ekohl @timja