### PR TITLE
Add Java packaging macros

### DIFF
--- a/macros.d/macros.javapackages-filesystem
+++ b/macros.d/macros.javapackages-filesystem
@@ -1,0 +1,84 @@
+#
+# RPM macros for Java filesystem layout.
+#
+# Copied from https://github.com/fedora-java/javapackages/blob/6.0.0/macros.d/macros.javapackages-filesystem
+#
+# JPackage Project  <http://www.jpackage.org/>
+#   David Walluck   <david@jpackage.org>
+#   Ville Skyttä    <scop at jpackage.org>
+#   Nicolas Mailhot <Nicolas.Mailhot@laPoste.net>
+#
+
+#==============================================================================
+# ---- default Java directories
+
+#
+# Root directory where all Java VMs/SDK/JREs are installed.
+#
+%_jvmdir        %{_prefix}/lib/jvm
+
+#
+# Root directory for all Java VM/SDK/JRE's private things.
+#
+%_jvmprivdir    %{_prefix}/lib/jvm-private
+
+#
+# Root directory for all architecture dependent parts of Java VM/SDK/JRE's
+#
+%_jvmlibdir     %{_prefix}/lib/jvm
+
+#
+# Root directory for all architecture independent parts of Java VM/SDK/JRE's
+#
+%_jvmdatadir    %{_datadir}/jvm
+
+#
+# Root directory for all configurations parts of Java VM/SDK/JRE's
+#
+%_jvmsysconfdir %{_sysconfdir}/jvm
+
+#
+# Root directory for all common architecture dependent parts of Java VM/SDK/JRE's
+#
+%_jvmcommonlibdir %{_prefix}/lib/jvm-common
+
+#
+# Root directory for all common architecture independent parts of Java VM/SDK/JRE's
+#
+%_jvmcommondatadir %{_datadir}/jvm-common
+
+#
+# Root directory for all common configurations parts of Java VM/SDK/JRE's
+#
+%_jvmcommonsysconfdir %{_sysconfdir}/jvm-common
+
+#
+# Directory containing Java configuration file (java.conf)
+#
+%_javaconfdir %{_sysconfdir}/java
+
+#
+# Directory where arch and version independent jars are installed.
+# This has already been integrated in RH macros following our request.
+#
+%_javadir       %{_datadir}/java
+
+#
+# Directory where arch-specific (JNI) version-independent jars are installed.
+#
+%_jnidir        %{_prefix}/lib/java
+
+#
+# Root directory where all javadoc is installed. Also already in RH macros.
+#
+%_javadocdir    %{_datadir}/javadoc
+
+#
+# Directory for Maven POM files
+#
+%_mavenpomdir   %{_datadir}/maven-poms
+
+#
+# Directory for Ivy XML files
+#
+%_ivyxmldir     %{_datadir}/ivy-xmls


### PR DESCRIPTION
These were removed from `rpm` in https://github.com/rpm-software-management/rpm/commit/a9199f17be42d22791caa33c1d79157b29b811d2

Fedora and OpenSUSE provide it to rpm specs via the `javapackages-tools` package which isn't packaged for ubuntu.

I've imported the relevant macro from Fedora: https://github.com/fedora-java/javapackages/blob/6.0.0/macros.d/macros.javapackages-filesystem

see https://github.com/jenkinsci/packaging/pull/317