### PR TITLE
Copy all macros

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -145,7 +145,7 @@ COPY --from=jenkins-agent /usr/local/bin/jenkins-agent /usr/local/bin/jenkins-ag
 ## Copy packaging-specific RPM macros
 COPY ./conf.d/rpm_macros /etc/rpm/macros
 COPY ./conf.d/devscripts.conf /etc/devscripts.conf
-COPY ./macros.d/macros.systemd /usr/lib/rpm/macros.d/macros.systemd
+COPY ./macros.d /usr/lib/rpm/macros.d
 
 # Create default user (must be the same as the official jenkins-agent image)
 ARG JENKINS_USERNAME=jenkins


### PR DESCRIPTION
I couldn't build this image on my machine before so didn't actually test https://github.com/jenkins-infra/docker-packaging/pull/34

turns out it individually added the systemd macro

I've tested this locally

separate PR incoming for making this image portable across architectures