### PR TITLE
Add gnupg2 required for rpm signing on Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update \
     git \
     gpg \
     gpg-agent \
+    gnupg2 \
     make \
     openssh-server \
     openssl \


### PR DESCRIPTION
See failing tests in https://github.com/jenkinsci/packaging/pull/317