### PR TITLE
chore: retrieve jx-release-version from github instead of its docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-ARG JX_RELEASE_VERSION=2.5.1
+ARG JX_RELEASE_VERSION=2.5.2
 ARG JENKINS_AGENT_VERSION=4.13-2
 
-FROM ghcr.io/jenkins-x/jx-release-version:${JX_RELEASE_VERSION} AS jx-release-version
 FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk11 AS jenkins-agent
 
 FROM ubuntu:22.04
@@ -56,6 +55,15 @@ RUN curl --silent --show-error --location --output /tmp/gh.tar.gz \
   && chmod a+x /usr/local/bin/gh \
   && gh --help
 
+## Repeating the ARGs from top level to allow them on this scope
+ARG JX_RELEASE_VERSION=2.5.2
+RUN curl --silent --show-error --location --output /tmp/jx-release-version.tar.gz \
+    "https://github.com/jenkins-x-plugins/jx-release-version/releases/download/v${JX_RELEASE_VERSION}/jx-release-version-linux-$(dpkg --print-architecture).tar.gz" \
+  && tar xvfz /tmp/jx-release-version.tar.gz -C /tmp && ls -artl /tmp \
+  && mv "/tmp/jx-release-version" /usr/bin/ \
+  && chmod a+x /usr/bin/jx-release-version \
+  && jx-release-version --help
+
 ARG AZURE_CLI_VERSION=2.37.0
 ## Always install the latest package and pip versions
 # hadolint ignore=DL3008,DL3013
@@ -75,10 +83,6 @@ RUN apt-get update \
   && az --version \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-## Repeating the ARGs from top level to allow them on this scope
-ARG JX_RELEASE_VERSION=2.5.1
-COPY --from=jx-release-version /usr/bin/jx-release-version /usr/bin/jx-release-version
 
 ## Always install the latest packages
 # hadolint ignore=DL3008

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-ARG JX_RELEASE_VERSION=2.5.2
 ARG JENKINS_AGENT_VERSION=4.13-2
 
 FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk11 AS jenkins-agent

--- a/Dockerfile
+++ b/Dockerfile
@@ -59,7 +59,7 @@ RUN curl --silent --show-error --location --output /tmp/gh.tar.gz \
 ARG JX_RELEASE_VERSION=2.5.2
 RUN curl --silent --show-error --location --output /tmp/jx-release-version.tar.gz \
     "https://github.com/jenkins-x-plugins/jx-release-version/releases/download/v${JX_RELEASE_VERSION}/jx-release-version-linux-$(dpkg --print-architecture).tar.gz" \
-  && tar xvfz /tmp/jx-release-version.tar.gz -C /tmp && ls -artl /tmp \
+  && tar xvfz /tmp/jx-release-version.tar.gz -C /tmp \
   && mv "/tmp/jx-release-version" /usr/bin/ \
   && chmod a+x /usr/bin/jx-release-version \
   && jx-release-version --help

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,6 @@ RUN curl --silent --show-error --location --output /tmp/gh.tar.gz \
   && chmod a+x /usr/local/bin/gh \
   && gh --help
 
-## Repeating the ARGs from top level to allow them on this scope
 ARG JX_RELEASE_VERSION=2.5.2
 RUN curl --silent --show-error --location --output /tmp/jx-release-version.tar.gz \
     "https://github.com/jenkins-x-plugins/jx-release-version/releases/download/v${JX_RELEASE_VERSION}/jx-release-version-linux-$(dpkg --print-architecture).tar.gz" \


### PR DESCRIPTION
The goal of this PR is to allow later on to build an `aarch64` `docker` image so that we can build on Oracle `aarch64` free tier,  Amazon Graviton 3, and so on...
The first step (for me, correct me if I'm wrong) is to allow the build for several architectures thanks to `buildx`.
Before changing the `Makefile`, I think we should get rid of `docker` images that are not multi-arch.

We were grabbing `jx-release-version` from a `docker` image which unfortunately is not yet multi-arch.
Following advice from @lemeurherve, I replaced this `FROM` with a direct installation from the `github` release process to have `jx-release-version` available for this image (the tool is released for several architectures (`amd64`, `arm64`, `arm32`).

I gave a try at `docker buildx build` with several platforms. 

`ubuntu 22.04` `docker` image is available for :
 * `linux/amd64`
 * `linux/arm/v7`
 * `linux/arm64/v8`
 * `linux/ppc64le`
 * `linux/riscv64`
 * `linux/s390x`

 Unfortunately, `jenkins/inbound-agent:4.13-2-jdk11` is only available for:
  * `linux/amd64`
  * `linux/arm64`
  * `linux/s390x`

`jx-release-version` is only available for :
 * `amd64`
 * `arm64`
 * `arm32`

Furthermore, `gh` is not available for `s390x`, which lets only `amd64` and `arm64` for this image.

While I was there, I changed the dependency of `jx-release-version` to `2.5.2`.