### PR TITLE
feat(updatecli): new manifest to keep updated the jenkins docker inbound agent

### DIFF
--- a/cst.yml
+++ b/cst.yml
@@ -9,8 +9,6 @@ metadataTest:
   labels:
     - key: 'project'
       value: 'https://github.com/jenkins-infra/docker-packaging'
-    - key: io.jenkins-infra.tools
-      value: "bash,debhelper,fakeroot,git,gpg,gh,jx-release-version,java,jv,jenkins-agent,make"
   user: jenkins
 
 fileExistenceTests:

--- a/cst.yml
+++ b/cst.yml
@@ -9,6 +9,8 @@ metadataTest:
   labels:
     - key: 'project'
       value: 'https://github.com/jenkins-infra/docker-packaging'
+    - key: io.jenkins-infra.tools
+      value: "bash,debhelper,fakeroot,git,gpg,gh,jx-release-version,java,jv,jenkins-agent,make"
   user: jenkins
 
 fileExistenceTests:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -65,3 +65,4 @@ pullrequests:
     spec:
       labels:
         - dependencies
+        - inbound-agent

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -16,7 +16,7 @@ scms:
 sources:
   lastVersion:
     kind: githubrelease
-    name: Get the latest jenkins-agent docker-inbound-agent version
+    name: Get the latest docker-inbound-agent version
     spec:
       owner: "jenkinsci"
       repository: "docker-inbound-agent"

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,0 +1,67 @@
+---
+title: "[jenkins-agent-version] Bump jenkins-agent version"
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get the latest jenkins-agent docker-inbound-agent version
+    spec:
+      owner: "jenkinsci"
+      repository: "docker-inbound-agent"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionFilter:
+        kind: latest
+
+conditions:
+  testDockerfile:
+    name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+  checkDockerImagePublished:
+    name: "Is latest dockerfile docker-inbound-agent image published?"
+    kind: dockerimage
+    sourceid: lastVersion
+    spec:
+      image: "jenkins/inbound-agent"
+      architecture: "amd64"
+      ## tag comes from the source
+
+targets:
+  updateDockerfileVersion:
+    name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
+    sourceid: lastVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_AGENT_VERSION"
+    scmid: default
+
+pullrequests:
+  default:
+    kind: github
+    scmid: default
+    targets:
+      - updateDockerfileVersion
+    spec:
+      labels:
+        - dependencies

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -36,7 +36,7 @@ conditions:
         keyword: "ARG"
         matcher: "JENKINS_AGENT_VERSION"
   checkDockerImagePublished:
-    name: "Is latest dockerfile docker-inbound-agent image published?"
+    name: "Is latest docker-inbound-agent image published?"
     kind: dockerimage
     sourceid: lastVersion
     spec:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,5 +1,5 @@
 ---
-title: "[jenkins-agent-version] Bump jenkins-agent version"
+title: "Bump inbound-agent version"
 
 scms:
   default:


### PR DESCRIPTION
as per https://github.com/jenkins-infra/docker-packaging/issues/44#event-7066220391

PULL REQUESTS
=============

[Dry Run] A pull request with kind "github" and title "[updatecli] [jenkins-agent-version] Bump jenkins-agent version" is expected.

=============================

REPORTS:


⚠ JENKINS-AGENT-VERSION.YML:
        Sources:
                ✔ [lastVersion] Get the latest jenkins-agent docker-inbound-agent version (kind: githubrelease)
        Condition:
                ✔ [checkDockerImagePublished] Is latest dockerfile docker-inbound-agent image published? (kind: dockerimage)
                ✔ [testDockerfile] Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION? (kind: dockerfile)
        Target:
                ⚠ [updateDockerfileVersion] Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile (kind: dockerfile)



Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1