### PR TITLE
breaking: switch to JDK17 for agent processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG JENKINS_AGENT_VERSION=3142.vcfca_0cd92128-1
 
-FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk11 AS jenkins-agent
+FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk17 AS jenkins-agent
 
 FROM ubuntu:22.04
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
@@ -129,7 +129,7 @@ USER $JENKINS_USERNAME
 
 RUN mkdir "${HOME}"/.ssh \
   && ssh-keyscan -t rsa pkg.origin.jenkins.io >> "${HOME}"/.ssh/known_hosts
-  
+
 RUN git config --global pull.rebase false
 
 LABEL io.jenkins-infra.tools="bash,debhelper,fakeroot,git,gpg,gh,jx-release-version,java,jv,jenkins-agent,make"

--- a/cst.yml
+++ b/cst.yml
@@ -61,3 +61,9 @@ fileExistenceTests:
     path: '/usr/bin/g++'
     shouldExist: true
     isExecutableBy: 'any'
+
+commandTests:
+  - name: "Check that `java` is present in the PATH and default to JDK17"
+    command: "java"
+    args: ["--version"]
+    expectedOutput: ["Temurin-17"]

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -38,6 +38,8 @@ conditions:
     name: "Is latest docker-inbound-agent image published?"
     kind: dockerimage
     sourceid: lastVersion
+    transformers:
+      - addsuffix: "-jdk17"
     spec:
       image: "jenkins/inbound-agent"
       architecture: "amd64"
@@ -55,9 +57,9 @@ targets:
         matcher: "JENKINS_AGENT_VERSION"
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump Jenkins inbound-agent version to {{ source "lastVersion" }}
     spec:


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3072