### PR TITLE
feat! add temuring JDK11 11.0.20+8 as default JDK (breaking)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 ARG JENKINS_AGENT_VERSION=3142.vcfca_0cd92128-1
+ARG JAVA_VERSION=11.0.20_8
+ARG JENKINS_AGENT_JDK_MAJOR=17
 
-FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk17 AS jenkins-agent
+FROM eclipse-temurin:${JAVA_VERSION}-jdk-jammy AS jdk
+FROM jenkins/inbound-agent:${JENKINS_AGENT_VERSION}-jdk${JENKINS_AGENT_JDK_MAJOR} AS jenkins-agent
 
 FROM ubuntu:22.04
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
@@ -90,9 +93,10 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-ENV JAVA_HOME=/opt/java/openjdk
+ENV JAVA_HOME=/opt/jdk-11
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jenkins-agent $JAVA_HOME $JAVA_HOME
+COPY --from=jenkins-agent /opt/java/openjdk /opt/jdk-17
+COPY --from=jdk /opt/java/openjdk ${JAVA_HOME}
 
 ## Use 1000 to be sure weight is always the bigger
 RUN update-alternatives --install /usr/bin/java java "${JAVA_HOME}"/bin/java 1000 \

--- a/cst.yml
+++ b/cst.yml
@@ -63,7 +63,11 @@ fileExistenceTests:
     isExecutableBy: 'any'
 
 commandTests:
-  - name: "Check that `java` is present in the PATH and default to JDK17"
-    command: "java"
+  - name: "Check that `java` binary for agent processes is present and defaults to JDK17"
+    command: "/opt/jdk-17/bin/java"
     args: ["--version"]
     expectedOutput: ["Temurin-17"]
+  - name: "Check that 'maven' and `java` are present in the PATH and default to JDK11 + 3.8.6"
+    command: "mvn"
+    args: ["-v"]
+    expectedOutput: ["Java version: 11.", "3.8.6"]

--- a/cst.yml
+++ b/cst.yml
@@ -63,7 +63,7 @@ fileExistenceTests:
     isExecutableBy: 'any'
 
 commandTests:
-  - name: "Check that `java` binary for agent processes is present and defaults to JDK17"
+  - name: "Check that `java` 17 binary for agent processes is present"
     command: "/opt/jdk-17/bin/java"
     args: ["--version"]
     expectedOutput: ["Temurin-17"]


### PR DESCRIPTION
#74 switched the default JDK11 (from the Jenkins agent image) to JDK17.

But (at least for today) Jenkins is built with JDK11 v11.0.20 so we need to keep the same JDK for now.

This PR adds back the JDK11 by separating explicitly the JDK from agent and the JDK for building.

The JDK for the agent is NOT added as the default in `update-aleternatives` as the `JAVA_HOME` is used for the build JDK e.g. the 11: this is a breaking change.

Note:
- No `updatecli` manifest added in this PR (in a subsequent one).