### PR TITLE
chore(updatecli) fixups for `jv` and Maven manifests

### DIFF
--- a/cst.yml
+++ b/cst.yml
@@ -70,4 +70,4 @@ commandTests:
   - name: "Check that 'maven' and `java` are present in the PATH and default to JDK11 + 3.8.6"
     command: "mvn"
     args: ["-v"]
-    expectedOutput: ["Java version: 11.", "3.8.6"]
+    expectedOutput: ["Java version: 11.", 3.8.6]

--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -42,9 +42,9 @@ targets:
         matcher: JV_VERSION
     scmid: default
 
-pullrequests:
+actions:
   default:
-    kind: github
+    kind: github/pullrequest
     scmid: default
     title: Bump `jv` CLI (jenkins-version) to {{ source "lastVersion" }}
     spec:

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -48,6 +48,14 @@ targets:
         keyword: "ARG"
         matcher: "MAVEN_VERSION"
     scmid: default
+  updateCstVersion:
+    name: "Update test harness with new Maven version"
+    sourceid: mavenVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "commandTests[1].expectedOutput[1]"
+    scmid: default
 
 actions:
   default:
@@ -58,4 +66,3 @@ actions:
       labels:
         - dependencies
         - maven
-


### PR DESCRIPTION
This PR introduces 2 fixes for updatecli manifests:

- Fixup of https://github.com/jenkins-infra/docker-packaging/pull/113: I forgot about the test harnes (adding a target to update Maven version in it)
- Fix of the `jv` manifest by updating `updatecli` deprecated keywords