### PR TITLE
chore(updatecli) manifest cleanup to remove deprecated instructions and handle future JDK21 upgrades

### DIFF
--- a/updatecli/updatecli.d/jdk-build.yml
+++ b/updatecli/updatecli.d/jdk-build.yml
@@ -62,7 +62,7 @@ targets:
     sourceid: lastVersion
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
@@ -72,7 +72,7 @@ targets:
     sourceid: majorJdkVersion
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: BUILD_JDK_MAJOR
@@ -85,7 +85,7 @@ targets:
       - addsuffix: '."'
     kind: yaml
     spec:
-      file: cst.yml
+      file: ./cst.yml
       key: $.commandTests[1].expectedOutput[0]
     scmid: default
 actions:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -1,3 +1,4 @@
+---
 name: Bump Jenkins inbound-agent version
 
 scms:
@@ -13,48 +14,54 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
+  agentMajorJdkVersion:
+    kind: shell
+    name: Get the agent major JDK version
+    spec:
+      command: echo "{{ .jdk.agentMajorVersion }}"
   lastVersion:
     kind: githubrelease
-    name: Get the latest version
+    name: Get the latest version of the Jenkins Inbound agent image
     spec:
-      owner: "jenkinsci"
-      repository: "docker-agent"
+      owner: jenkinsci
+      repository: docker-agent
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
         kind: latest
 
 conditions:
-  testDockerfile:
-    name: "Does the Dockerfile have an ARG instruction which key is JENKINS_AGENT_VERSION?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "JENKINS_AGENT_VERSION"
   checkDockerImagePublished:
     name: "Is latest docker-inbound-agent image published?"
     kind: dockerimage
     sourceid: lastVersion
     transformers:
-      - addsuffix: "-jdk17"
+      - addsuffix: -jdk{{ source "agentMajorJdkVersion" }}
     spec:
       image: "jenkins/inbound-agent"
       architecture: "amd64"
       ## tag comes from the source
 
 targets:
-  updateDockerfileVersion:
-    name: "Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile"
+  updateDockerfileAgentVersion:
+    name: Update the value of ARG JENKINS_AGENT_VERSION in the Dockerfile
     sourceid: lastVersion
     kind: dockerfile
     spec:
       file: Dockerfile
       instruction:
-        keyword: "ARG"
-        matcher: "JENKINS_AGENT_VERSION"
+        keyword: ARG
+        matcher: JENKINS_AGENT_VERSION
+    scmid: default
+  updateDockerfileAgentJDKVersion:
+    name: Update the value of ARG JENKINS_AGENT_JDK_MAJOR in the Dockerfile
+    sourceid: agentMajorJdkVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JENKINS_AGENT_JDK_MAJOR
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jenkins-agent-version.yml
+++ b/updatecli/updatecli.d/jenkins-agent-version.yml
@@ -48,7 +48,7 @@ targets:
     sourceid: lastVersion
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: JENKINS_AGENT_VERSION
@@ -58,7 +58,7 @@ targets:
     sourceid: agentMajorJdkVersion
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: JENKINS_AGENT_JDK_MAJOR

--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -1,3 +1,4 @@
+---
 name: Bump `jv` CLI (jenkins-version)
 
 scms:
@@ -21,19 +22,9 @@ sources:
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
 
-conditions:
-  dockerfileInstruction:
-    name: "Does the Dockerfile have an ARG instruction which key is JV_VERSION?"
-    kind: dockerfile
-    spec:
-      file: Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JV_VERSION
-
 targets:
   updateDockerfile:
-    name: "Bump JV_VERSION value"
+    name: Bump JV_VERSION value
     kind: dockerfile
     spec:
       file: Dockerfile

--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -27,7 +27,7 @@ targets:
     name: Bump JV_VERSION value
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: JV_VERSION

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -18,8 +18,8 @@ sources:
     kind: githubrelease
     name: Get the latest Maven version
     spec:
-      owner: "apache"
-      repository: "maven"
+      owner: apache
+      repository: maven
       token: "{{ requiredEnv .github.token }}"
       username: "{{ .github.username }}"
       versionfilter:
@@ -36,25 +36,24 @@ conditions:
     spec:
       command: curl --connect-timeout 5 --location --head --fail --silent --show-error https://archive.apache.org/dist/maven/maven-3/{{ source `mavenVersion` }}/binaries/apache-maven-{{ source `mavenVersion` }}-bin.tar.gz
 
-
 targets:
   updateDockerfileVersion:
-    name: "Update the value of ARG MAVEN_VERSION in the Dockerfile"
+    name: Update the value of ARG MAVEN_VERSION in the Dockerfile
     sourceid: mavenVersion
     kind: dockerfile
     spec:
       file: Dockerfile
       instruction:
-        keyword: "ARG"
-        matcher: "MAVEN_VERSION"
+        keyword: ARG
+        matcher: MAVEN_VERSION
     scmid: default
   updateCstVersion:
-    name: "Update test harness with new Maven version"
+    name: Update test harness with new Maven version
     sourceid: mavenVersion
     kind: yaml
     spec:
-      file: "cst.yml"
-      key: "commandTests[1].expectedOutput[1]"
+      file: ./cst.yml
+      key: $.commandTests[1].expectedOutput[1]
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/maven.yaml
+++ b/updatecli/updatecli.d/maven.yaml
@@ -42,7 +42,7 @@ targets:
     sourceid: mavenVersion
     kind: dockerfile
     spec:
-      file: Dockerfile
+      file: ./Dockerfile
       instruction:
         keyword: ARG
         matcher: MAVEN_VERSION

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -10,3 +10,4 @@ github:
 
 jdk:
   majorVersion: 17
+  agentMajorVersion: 17


### PR DESCRIPTION
This PR is a follow up of the work done in #111 and #115 by @jayfranco999 and I.

The goal is to cleanup the manifest to:

- Ensure Jenkins agent version is ready for upcoming JDK21 by using the same technique as we did in #115 
- Remove deprecated messages from `updatecli`
- Ensure homogeneity between manifests and stricter YAML syntax
- Help beginners by making relative path explicit