### PR TITLE
chore: separate updatecli to its own pipeline

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,1 +1,8 @@
+String cronTriggerExpression = ''
+if (env.BRANCH_IS_PRIMARY) {
+    cronTriggerExpression = '@weekly'
+}
+
+properties([pipelineTriggers([cron(cronTriggerExpression)])])
+
 buildDockerAndPublishImage('packaging', [targetplatforms: 'linux/amd64,linux/arm64'])

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -1,8 +1,1 @@
-parallelDockerUpdatecli([
-  imageName: 'packaging',
-  rebuildImageOnPeriodicJob: false,
-  buildDockerConfig : [
-    useContainer: false,
-    targetplatforms: 'linux/amd64,linux/arm64'
-  ]
-])
+buildDockerAndPublishImage('packaging', [targetplatforms: 'linux/amd64,linux/arm64'])

--- a/Jenkinsfile_updatecli
+++ b/Jenkinsfile_updatecli
@@ -1,0 +1,4 @@
+updatecli(action: 'diff')
+if (env.BRANCH_IS_PRIMARY) {
+    updatecli(action: 'apply', cronTriggerExpression: '@weekly')
+}

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,8 +1,7 @@
 ---
 github:
-  user: "Jenkins Infra Bot (updatecli)"
-  email: "60776566+jenkins-infra-bot@users.noreply.github.com"
-  username: "jenkins-infra-bot"
+  user: "jenkins-infra-updatecli"
+  email: "178728+jenkins-infra-updatecli[bot]@users.noreply.github.com"
   token: "UPDATECLI_GITHUB_TOKEN"
   branch: "main"
   owner: "jenkins-infra"


### PR DESCRIPTION
This PR separates updatecli to its own pipeline and uses https://github.com/apps/jenkins-infra-updatecli instead of https://github.com/jenkins-infra-bot in updatecli values.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2778