### PR TITLE
chore: remove unneeded arm64 builds

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -5,4 +5,4 @@ if (env.BRANCH_IS_PRIMARY) {
 
 properties([pipelineTriggers([cron(cronTriggerExpression)])])
 
-buildDockerAndPublishImage('packaging', [targetplatforms: 'linux/amd64,linux/arm64'])
+buildDockerAndPublishImage('packaging', [targetplatforms: 'linux/amd64'])


### PR DESCRIPTION
Reverts https://github.com/jenkins-infra/docker-packaging/pull/124 to help in https://github.com/jenkins-infra/docker-packaging/pull/133 to support Ubuntu 24.04 builds