### PR TITLE
chore(updatecli): change major jdk to 21

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -9,5 +9,5 @@ github:
   repository: "docker-packaging"
 
 jdk:
-  majorVersion: 17
-  agentMajorVersion: 17
+  majorVersion: 21
+  agentMajorVersion: 21

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -9,5 +9,5 @@ github:
   repository: "docker-packaging"
 
 jdk:
-  majorVersion: 21
+  majorVersion: 17
   agentMajorVersion: 21


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4121

use updatecli to generate the new PR to upgrade from jdk17 to jdk21