### PR TITLE
chore(updatecli): change the jdk used for pipelines from jdk17 to jdk21

### DIFF
--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -9,5 +9,5 @@ github:
   repository: "docker-packaging"
 
 jdk:
-  majorVersion: 17
+  majorVersion: 21
   agentMajorVersion: 21


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4127#issue-2335969330

this will switch the agent image to use jdk21 not only as runtime build also at buildtime meaning to be used by pipelines. 
⚠️ This will be a breaking change on the first PR produced that will be merged