### PR TITLE
feat: add azcopy in the image with the corresponding updatecli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ LABEL project="https://github.com/jenkins-infra/docker-packaging"
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ## Always install the latest package versions
 # hadolint ignore=DL3008,DL3013
@@ -83,6 +83,29 @@ RUN apt-get update \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+## Install azcopy
+ARG AZCOPY_VERSION=10.29.1
+RUN ARCH="$(uname -m)"; \
+    case "${ARCH}" in \
+        aarch64|arm64) \
+            azcopy_arch="arm64"; \
+            ;; \
+        amd64|x86_64) \
+            azcopy_arch="x86_64"; \
+            ;; \
+        *) \
+            echo "Unsupported arch: ${ARCH}"; \
+            exit 1; \
+            ;; \
+    esac; \
+    azcopy_pkg="$(mktemp)" \
+    && curl --silent --show-error --location --output "${azcopy_pkg}" "https://github.com/Azure/azure-storage-azcopy/releases/download/v${AZCOPY_VERSION}/azcopy-${AZCOPY_VERSION}.${azcopy_arch}.deb" \
+    && dpkg --install "${azcopy_pkg}" \
+    # Sanity check
+    && azcopy --version \
+    # Cleanup
+    && rm -f "${azcopy_pkg}"
+
 ## Always install the latest packages
 # hadolint ignore=DL3008
 RUN apt-get update \
@@ -94,7 +117,7 @@ RUN apt-get update \
 # Repeat ARG to scope it in this stage
 ARG BUILD_JDK_MAJOR=21
 ENV JAVA_HOME=/opt/jdk-"${BUILD_JDK_MAJOR}"
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 ## Note: when using the same major versions, the temurin JDK overrides the agent JDK.
 ##    We need to keep this behavior as both JDK can differ. The long term solution is to switch this image to the "all in one".
@@ -141,6 +164,7 @@ RUN mkdir "${HOME}"/.ssh \
 
 RUN git config --global pull.rebase false
 
+ARG JENKINS_AGENT_VERSION=3309.v27b_9314fd1a_4-7
 LABEL io.jenkins-infra.tools="bash,debhelper,fakeroot,git,gpg,gh,jx-release-version,java,jv,jenkins-agent,make"
 LABEL io.jenkins-infra.tools.gh.version="${GH_VERSION}"
 LABEL io.jenkins-infra.tools.jx-release-version.version="${JX_RELEASE_VERSION}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -170,6 +170,6 @@ LABEL io.jenkins-infra.tools.gh.version="${GH_VERSION}"
 LABEL io.jenkins-infra.tools.jx-release-version.version="${JX_RELEASE_VERSION}"
 LABEL io.jenkins-infra.tools.jenkins-agent.version="${JENKINS_AGENT_VERSION}"
 LABEL io.jenkins-infra.tools.jv.version="${JV_VERSION}"
-
+LABEL io.jenkins-infra.tools.azcopy.version="${AZCOPY_VERSION}"
 
 ENTRYPOINT ["/usr/local/bin/jenkins-agent"]

--- a/cst.yml
+++ b/cst.yml
@@ -8,6 +8,8 @@ metadataTest:
   labels:
     - key: 'project'
       value: 'https://github.com/jenkins-infra/docker-packaging'
+    - key: io.jenkins-infra.tools.azcopy.version
+      value: 10.29.1
   user: jenkins
 fileExistenceTests:
   - name: 'RPM Macros'
@@ -59,6 +61,10 @@ fileExistenceTests:
     path: '/usr/bin/g++'
     shouldExist: true
     isExecutableBy: 'any'
+  - name: "azcopy"
+    path: "/usr/bin/azcopy"
+    shouldExist: true
+    isExecutableBy: "any"
 commandTests:
   - name: Check that `java` 21 binary for agent processes is present
     command: /opt/jdk-21/bin/java

--- a/updatecli/updatecli.d/azcopy.yaml
+++ b/updatecli/updatecli.d/azcopy.yaml
@@ -1,0 +1,85 @@
+---
+name: Bump `azcopy` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `azcopy` version
+    spec:
+      owner: Azure
+      repository: azure-storage-azcopy
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+    transformers:
+      - trimprefix: 'v'
+
+conditions:
+  testDockerfileArgAzCliVersion:
+    name: "Does the Dockerfile have an ARG instruction which key is AZCOPY_VERSION?"
+    kind: dockerfile
+    disablesourceinput: true
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AZCOPY_VERSION"
+  testCstAzCliVersion:
+    name: "Does the test harness checks for a label io.jenkins-infra.tools.azcopy.version?"
+    kind: yaml
+    disablesourceinput: true
+    spec:
+      file: "cst.yml"
+      key: "$.metadataTest.labels[1].key"
+      value: io.jenkins-infra.tools.azcopy.version
+  checkx86DebPackage:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://github.com/Azure/azure-storage-azcopy/releases/download/v{{ source "lastReleaseVersion" }}/azcopy-{{ source "lastReleaseVersion" }}.x86_64.deb
+  checkArm64DebPackage:
+    kind: file
+    disablesourceinput: true
+    spec:
+      file: https://github.com/Azure/azure-storage-azcopy/releases/download/v{{ source "lastReleaseVersion" }}/azcopy-{{ source "lastReleaseVersion" }}.arm64.deb
+
+targets:
+  updateCstVersion:
+    name: "Update the label io.jenkins-infra.tools.azcopy.version in the test harness"
+    sourceid: lastReleaseVersion
+    kind: yaml
+    spec:
+      file: "cst.yml"
+      key: "$.metadataTest.labels[1].value"
+    scmid: default
+  updateDockerfileArgVersion:
+    name: "Update the value of ARG AZCOPY_VERSION in the Dockerfile"
+    sourceid: lastReleaseVersion
+    kind: dockerfile
+    spec:
+      file: Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "AZCOPY_VERSION"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump azcopy version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - enhancement
+        - azcopy


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/4696#issuecomment-3052689033
we need azcopy in this image to be used with the new private report monitoring system